### PR TITLE
chore: replace casuarius with dagga

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ systems do the hot-path work that completes those async operations as fast as po
       }
   }
 
-  fn lastly((u32_number, f32_number): (Read<u32>, Read<f32>)) -> anyhow::Result<ShouldContinue> {
+  fn lastly(
+      (u32_number, f32_number): (Read<u32>, Read<f32>),
+  ) -> anyhow::Result<ShouldContinue> {
       if *u32_number == 2 && *f32_number == 3.0 {
           end()
       } else {
@@ -158,35 +160,37 @@ systems do the hot-path work that completes those async operations as fast as po
   let mut world = World::default();
   world
       // one should run before two
-      .with_system_with_dependencies("one", one, &[], &["two"]).unwrap()
+      .with_system_with_dependencies("one", one, &[], &["two"])
+      .unwrap()
       // two should run after one - this is redundant but good for illustration
-      .with_system_with_dependencies("two", two, &["one"], &[]).unwrap()
+      .with_system_with_dependencies("two", two, &["one"], &[])
+      .unwrap()
       // exit_on_three has no dependencies
-      .with_system("run_thrice_and_leave", exit_on_three).unwrap()
+      .with_system("exit_on_three", exit_on_three)
+      .unwrap()
       // all systems after a barrier run after the systems before a barrier
       .with_system_barrier()
-      .with_system("lastly", lastly).unwrap();
+      .with_system("lastly", lastly)
+      .unwrap();
 
   assert_eq!(
       vec![
-          vec!["one"],
-          vec!["run_thrice_and_leave", "two"],
+          vec!["one", "exit_on_three"],
+          vec!["two"],
           vec!["lastly"],
       ],
       world.get_sync_schedule_names()
   );
 
-  world.tick();
+  world.tick().unwrap();
+
   assert_eq!(
-      vec![
-          vec!["run_thrice_and_leave"],
-          vec!["lastly"],
-      ],
+      vec![vec!["exit_on_three"], vec!["lastly"],],
       world.get_sync_schedule_names()
   );
 
-  world.tick();
-  world.tick();
+  world.tick().unwrap();
+  world.tick().unwrap();
   assert!(world.get_sync_schedule_names().is_empty());
   ```
 - component storage

--- a/crates/apecs/Cargo.toml
+++ b/crates/apecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apecs"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["gamedev", "ecs", "async"]
@@ -30,7 +30,7 @@ async-broadcast = "^0.4"
 async-channel = "^1.6"
 async-executor = "^1.4"
 async-oneshot = "^0.5"
-dagga = { git = "https://github.com/schell/dagga.git", default-features = false }
+dagga = { version = "^0.1", default-features = false }
 itertools = "^0.10"
 log = "^0.4"
 parking_lot = "^0.12"

--- a/crates/apecs/Cargo.toml
+++ b/crates/apecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apecs"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["gamedev", "ecs", "async"]
@@ -30,7 +30,7 @@ async-broadcast = "^0.4"
 async-channel = "^1.6"
 async-executor = "^1.4"
 async-oneshot = "^0.5"
-casuarius = "^0.1"
+dagga = { git = "https://github.com/schell/dagga.git", default-features = false }
 itertools = "^0.10"
 log = "^0.4"
 parking_lot = "^0.12"

--- a/crates/apecs/src/lib.rs
+++ b/crates/apecs/src/lib.rs
@@ -128,7 +128,31 @@ pub mod internal {
     use anyhow::Context;
 
     pub use super::resource_manager::LoanManager;
-    pub use super::schedule::Borrow;
+
+    /// Describes borrowing of system resources at runtime. For internal use,
+    /// mostly.
+    #[derive(Clone, Debug)]
+    pub struct Borrow {
+        pub id: ResourceId,
+        pub is_exclusive: bool,
+    }
+
+    impl Borrow {
+        /// The resource id
+        pub fn rez_id(&self) -> ResourceId {
+            self.id.clone()
+        }
+
+        /// The type name of the resource
+        pub fn name(&self) -> &str {
+            self.id.name
+        }
+
+        /// Whether this borrow is mutable (`true`) or immutable (`false`).
+        pub fn is_exclusive(&self) -> bool {
+            self.is_exclusive
+        }
+    }
 
     /// A type-erased resource.
     pub struct Resource {
@@ -531,8 +555,7 @@ impl<T: IsResource, G: Gen<T>> Read<T, G> {
     }
 }
 
-pub(crate) struct Request {
-    // TODO: add a type_name field that could add in debugging
+pub struct Request {
     pub borrows: Vec<internal::Borrow>,
     pub construct: fn(&mut LoanManager<'_>) -> anyhow::Result<Resource>,
     pub deploy_tx: spsc::Sender<Resource>,

--- a/crates/apecs/src/resource_manager.rs
+++ b/crates/apecs/src/resource_manager.rs
@@ -10,8 +10,7 @@ use crate::Gen;
 
 use super::{
     chan::mpsc,
-    internal::{FetchReadyResource, Resource},
-    schedule::Borrow,
+    internal::{FetchReadyResource, Resource, Borrow},
     IsResource, ResourceId,
 };
 
@@ -22,7 +21,7 @@ pub struct ExclusiveResourceReturnChan(
 );
 
 /// Performs loans on behalf of the world.
-pub(crate) struct ResourceManager {
+pub struct ResourceManager {
     // Resources held for the world's systems
     pub world_resources: FxHashMap<ResourceId, Resource>,
     // Resources currently on loan from this struct to the world's systems

--- a/crates/apecs/src/storage/archetype/query.rs
+++ b/crates/apecs/src/storage/archetype/query.rs
@@ -10,7 +10,7 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterato
 use crate as apecs;
 use crate::{
     resource_manager::LoanManager,
-    schedule::Borrow,
+    internal::Borrow,
     storage::{
         archetype::{Archetype, Components},
         Entry,


### PR DESCRIPTION
This moves the scheduling into a new crate, `dagga`, which is implemented using the AC3 constraint satisfaction algorithm limited to only expressions of `<`, `>` and `!=`. This is instead of using cassowary for scheduling which is quite a large system in itself. This should make `apecs`'s scheduling faster, but at the very least it makes it easy to understand and debug.

This also has the benefit that `dagga` can be used for scheduling other things like other ECS libs, render graphs etc.