### PR TITLE
chore: replace resource manager w/ broomdog

### DIFF
--- a/crates/apecs/Cargo.toml
+++ b/crates/apecs/Cargo.toml
@@ -30,6 +30,7 @@ async-broadcast = "^0.4"
 async-channel = "^1.6"
 async-executor = "^1.4"
 async-oneshot = "^0.5"
+broomdog = { path = "../../../broomdog" }
 dagga = { version = "^0.1", default-features = false }
 itertools = "^0.10"
 log = "^0.4"

--- a/crates/apecs/src/plugin.rs
+++ b/crates/apecs/src/plugin.rs
@@ -3,7 +3,7 @@
 //! Systems and resources can be composed together using the [`Plugin`] builder.
 //! The resulting plugin can then be instantiated with
 //! [`crate::World::with_plugin`].
-use std::{future::Future, any::TypeId};
+use std::future::Future;
 
 use dagga::Node;
 
@@ -12,13 +12,14 @@ use crate::{
     // schedule::Dependency,
     system::{AsyncSystemFuture, ShouldContinue, System},
     world::Facade,
+    internal::TypeKey,
     CanFetch,
     IsResource,
     LazyResource,
     World,
 };
 
-pub struct SyncSystemWithDeps(pub Node<System, TypeId>);
+pub struct SyncSystemWithDeps(pub Node<System, TypeKey>);
 
 impl SyncSystemWithDeps {
     pub fn new<T, F>(

--- a/crates/apecs/src/resource_manager.rs
+++ b/crates/apecs/src/resource_manager.rs
@@ -1,90 +1,46 @@
 //! Manages system resources.
 //!
 //! This module should not need to be used by most users of this library.
-use std::sync::Arc;
-
 use anyhow::Context;
-use rustc_hash::{FxHashMap, FxHashSet};
+use broomdog::TypeMap;
 
 use crate::Gen;
 
 use super::{
-    chan::mpsc,
-    internal::{FetchReadyResource, Resource, Borrow},
-    IsResource, ResourceId,
+    internal::{Borrow, FetchReadyResource, TypeValue},
+    IsResource, TypeKey,
 };
 
-/// Systems use this to return resources borrowed exclusively.
-pub struct ExclusiveResourceReturnChan(
-    mpsc::Sender<(ResourceId, Resource)>,
-    mpsc::Receiver<(ResourceId, Resource)>,
-);
-
 /// Performs loans on behalf of the world.
+#[derive(Default)]
 pub struct ResourceManager {
-    // Resources held for the world's systems
-    pub world_resources: FxHashMap<ResourceId, Resource>,
-    // Resources currently on loan from this struct to the world's systems
-    //
-    // A system borrowing a resource in this field only has a reference to the
-    // resources.
-    pub loaned_refs: FxHashMap<ResourceId, Arc<Resource>>,
-    // Resources currently on loan from this struct to the world's systems.
-    //
-    // A system borrowing a resource in this field has an exclusive, mutable
-    // borrow to the resource.
-    pub loaned_muts: FxHashSet<ResourceId>,
-    // A channel that systems use to return loaned resources
-    pub exclusive_return_chan: ExclusiveResourceReturnChan,
-}
-
-impl Default for ResourceManager {
-    fn default() -> Self {
-        let (tx, rx) = mpsc::unbounded();
-        Self {
-            world_resources: Default::default(),
-            loaned_refs: Default::default(),
-            loaned_muts: Default::default(),
-            exclusive_return_chan: ExclusiveResourceReturnChan(tx, rx),
-        }
-    }
+    pub type_map: TypeMap,
 }
 
 impl ResourceManager {
-    /// Get a sender that can be used to return resources.
-    pub fn exclusive_resource_return_sender(&self) -> mpsc::Sender<(ResourceId, Resource)> {
-        self.exclusive_return_chan.0.clone()
+    pub fn add<T: IsResource>(&mut self, rez: T) -> Option<TypeValue> {
+        self.insert(TypeKey::new::<T>(), TypeValue::new(rez))
     }
 
-    pub fn add<T: IsResource>(&mut self, rez: T) -> Option<Resource> {
-        self.insert(ResourceId::new::<T>(), Resource::from(Box::new(rez)))
+    pub fn insert(&mut self, id: TypeKey, boxed_rez: TypeValue) -> Option<TypeValue> {
+        self.type_map.insert(id, boxed_rez)
     }
 
-    pub fn insert(&mut self, id: ResourceId, boxed_rez: Resource) -> Option<Resource> {
-        self.world_resources.insert(id, boxed_rez)
+    pub fn has_resource(&self, key: &TypeKey) -> bool {
+        self.type_map.contains_key(key)
     }
 
-    pub fn has_resource(&self, key: &ResourceId) -> bool {
-        self.world_resources.contains_key(key)
-            || self.loaned_refs.contains_key(key)
-            || self.loaned_muts.contains(key)
-    }
-
-    pub fn get<T: IsResource>(&self, key: &ResourceId) -> anyhow::Result<&T> {
-        let rez: &Resource = self
-            .world_resources
-            .get(key)
-            .with_context(|| format!("resource {} is missing", key.name))?;
-        rez.downcast_ref()
+    pub fn get<T: IsResource>(&self) -> anyhow::Result<&T> {
+        let may_t = self.type_map.get_value::<T>()?;
+        let t = may_t.with_context(|| format!("missing {}", std::any::type_name::<T>()))?;
+        Ok(t)
     }
 
     pub fn get_mut<T: IsResource>(&mut self) -> anyhow::Result<&mut T> {
-        let key = ResourceId::new::<T>();
-        let rez: &mut Resource = self
-            .world_resources
-            .get_mut(&key)
-            .with_context(|| format!("resource {} is missing", key.name))?;
-        rez.downcast_mut()
+        let may_t = self.type_map.get_value_mut::<T>()?;
+        let t =
+            may_t.with_context(|| format!("resource {} is missing", std::any::type_name::<T>()))?;
+        Ok(t)
     }
 
     fn missing_msg(label: &str, borrow: &Borrow, extra: &str) -> String {
@@ -92,7 +48,7 @@ impl ResourceManager {
             r#"'{}' requested missing resource "{}" encountered while building request: {}
 "#,
             label,
-            borrow.rez_id().name,
+            borrow.rez_id().name(),
             extra
         )
     }
@@ -103,46 +59,23 @@ impl ResourceManager {
         borrow: &Borrow,
     ) -> anyhow::Result<FetchReadyResource> {
         let rez_id = borrow.rez_id();
-        let ready_rez: FetchReadyResource = match self.world_resources.remove(&rez_id) {
-            Some(rez) => {
-                if borrow.is_exclusive() {
-                    assert!(self.loaned_muts.insert(rez_id), "already mutably borrowed",);
-                    FetchReadyResource::Owned(rez)
-                } else {
-                    let arc_rez = Arc::new(rez);
-                    if !self.loaned_refs.contains_key(&rez_id) {
-                        let _ = self.loaned_refs.insert(rez_id, arc_rez.clone());
-                    }
-                    FetchReadyResource::Ref(arc_rez)
-                }
-            }
-            None => {
-                // it's not in the main map, so maybe it was previously borrowed
-                if borrow.is_exclusive() {
-                    anyhow::bail!(Self::missing_msg(
-                        label,
-                        &borrow,
-                        "the borrow is exclusive and the resource is missing"
-                    ))
-                } else {
-                    let rez: &Arc<Resource> =
-                        self.loaned_refs.get(&rez_id).context(Self::missing_msg(
-                            label,
-                            &borrow,
-                            "the borrow is not exclusive but the resource is missing from \
-                             previously borrowed resources",
-                        ))?;
-                    FetchReadyResource::Ref(rez.clone())
-                }
-            }
-        };
-
-        Ok(ready_rez)
-    }
-
-    /// Returns whether any resources are out on loan
-    pub fn are_any_resources_on_loan(&self) -> bool {
-        !(self.loaned_muts.is_empty() && self.loaned_refs.is_empty())
+        Ok(if borrow.is_exclusive() {
+            let may_loan = self.type_map.loan_mut(rez_id)?;
+            anyhow::ensure!(
+                may_loan.is_some(),
+                Self::missing_msg(label, &borrow, "resource has not been inserted")
+            );
+            log::trace!("loaning exclusive {}", rez_id.name());
+            FetchReadyResource::Owned(may_loan.unwrap())
+        } else {
+            let may_loan = self.type_map.loan(rez_id)?;
+            anyhow::ensure!(
+                may_loan.is_some(),
+                Self::missing_msg(label, &borrow, "resource has not been inserted")
+            );
+            log::trace!("loaning {}", rez_id.name());
+            FetchReadyResource::Ref(may_loan.unwrap())
+        })
     }
 
     /// Unify all resources by collecting them from loaned refs and
@@ -152,15 +85,7 @@ impl ResourceManager {
     /// Use `try_unify_resources` if you would like not to err.
     pub fn unify_resources(&mut self, label: &str) -> anyhow::Result<()> {
         log::trace!("unify resources {}", label);
-        let resources_are_still_loaned = self.try_unify_resources(label)?;
-        if resources_are_still_loaned {
-            anyhow::bail!(
-                "{} cannot unify resources, some are still on loan:\n{}",
-                label,
-                self.resources_on_loan_msg()
-            )
-        }
-
+        self.type_map.unify()?;
         Ok(())
     }
 
@@ -173,49 +98,8 @@ impl ResourceManager {
     /// actually happen.
     pub fn try_unify_resources(&mut self, label: &str) -> anyhow::Result<bool> {
         log::trace!("try unify resources {}", label);
-        while let Ok((rez_id, resource)) = self.exclusive_return_chan.1.try_recv() {
-            // put the exclusively borrowed resources back, there should be nothing stored
-            // there currently
-            let prev = self.world_resources.insert(rez_id.clone(), resource);
-            debug_assert!(prev.is_none());
-            anyhow::ensure!(
-                self.loaned_muts.remove(&rez_id),
-                "{} was not removed from loaned_muts",
-                rez_id.name
-            );
-        }
-
-        // put the loaned ref resources back
-        if self.are_any_resources_on_loan() {
-            for (id, rez) in std::mem::take(&mut self.loaned_refs).into_iter() {
-                match Arc::try_unwrap(rez) {
-                    Ok(rez) => anyhow::ensure!(
-                        self.world_resources.insert(id, rez).is_none(),
-                        "duplicate resources"
-                    ),
-                    Err(arc_rez) => {
-                        log::error!(
-                            "could not retreive borrowed resource {:?}, it is still borrowed by \
-                             '{}' - do not to hold loaned resources over an await point",
-                            id.name, label,
-                        );
-                        let _ = self.loaned_refs.insert(id, arc_rez);
-                    }
-                }
-            }
-        }
-
-        Ok(self.are_any_resources_on_loan())
-    }
-
-    /// Returns a message about resources out on loan.
-    pub fn resources_on_loan_msg(&self) -> String {
-        self.loaned_refs
-            .keys()
-            .map(|id| format!("  & {}", id.name))
-            .chain(self.loaned_muts.iter().map(|id| format!("    {}", id.name)))
-            .collect::<Vec<_>>()
-            .join("\n")
+        let err = self.type_map.unify().is_err();
+        Ok(err)
     }
 
     /// Mutably borrow as a [`LoanManager`].
@@ -242,7 +126,7 @@ impl<'a> LoanManager<'a> {
         label: &str,
         borrow: &Borrow,
     ) -> anyhow::Result<FetchReadyResource> {
-        let rez_id = ResourceId::new::<T>();
+        let rez_id = TypeKey::new::<T>();
         if self.0.has_resource(&rez_id) {
             self.0.get_loaned(label, borrow)
         } else {
@@ -251,10 +135,10 @@ impl<'a> LoanManager<'a> {
                 std::any::type_name::<T>()
             );
             let t: T = G::generate()
-                .with_context(|| format!("could not make default value for {}", rez_id.name))?;
+                .with_context(|| format!("could not make default value for {}", rez_id.name()))?;
             let prev = self
                 .0
-                .insert(ResourceId::new::<T>(), Resource::from(Box::new(t)));
+                .insert(TypeKey::new::<T>(), TypeValue::from(Box::new(t)));
             debug_assert!(prev.is_none());
             self.0.get_loaned(label, borrow)
         }
@@ -263,11 +147,6 @@ impl<'a> LoanManager<'a> {
     /// Attempt to get a mutable reference to a resource.
     pub fn get_mut<T: IsResource>(&mut self) -> anyhow::Result<&mut T> {
         self.0.get_mut::<T>()
-    }
-
-    /// Get a clone of the resource return channel sender.
-    pub fn resource_return_tx(&self) -> mpsc::Sender<(ResourceId, Resource)> {
-        self.0.exclusive_resource_return_sender()
     }
 }
 

--- a/crates/apecs/src/storage/archetype/query.rs
+++ b/crates/apecs/src/storage/archetype/query.rs
@@ -15,7 +15,7 @@ use crate::{
         archetype::{Archetype, Components},
         Entry,
     },
-    CanFetch, Read, ResourceId,
+    CanFetch, Read, TypeKey,
 };
 
 use super::IsBundle;
@@ -79,7 +79,7 @@ impl<'s, T: Send + Sync + 'static> IsQuery for &'s T {
 
     fn borrows() -> Vec<Borrow> {
         vec![Borrow {
-            id: ResourceId::new::<ComponentColumn<T>>(),
+            id: TypeKey::new::<ComponentColumn<T>>(),
             is_exclusive: false,
         }]
     }
@@ -157,7 +157,7 @@ impl<'s, T: Send + Sync + 'static> IsQuery for &'s mut T {
 
     fn borrows() -> Vec<Borrow> {
         vec![Borrow {
-            id: ResourceId::new::<ComponentColumn<T>>(),
+            id: TypeKey::new::<ComponentColumn<T>>(),
             is_exclusive: true,
         }]
     }

--- a/crates/apecs/src/system.rs
+++ b/crates/apecs/src/system.rs
@@ -1,10 +1,14 @@
-use std::{any::TypeId, future::Future, pin::Pin, sync::atomic::AtomicU64};
+use std::{future::Future, pin::Pin, sync::atomic::AtomicU64};
 
 use anyhow::Context;
 use dagga::Node;
 use itertools::Itertools;
 
-use super::{resource_manager::LoanManager, CanFetch, Resource};
+use crate::{
+    internal::{TypeKey, TypeValue},
+    resource_manager::LoanManager,
+    CanFetch,
+};
 
 static SYSTEM_ITERATION: AtomicU64 = AtomicU64::new(0);
 
@@ -53,15 +57,15 @@ pub fn err(err: anyhow::Error) -> anyhow::Result<ShouldContinue> {
 }
 
 pub type SystemFunction =
-    Box<dyn FnMut(Resource) -> anyhow::Result<ShouldContinue> + Send + Sync + 'static>;
+    Box<dyn FnMut(TypeValue) -> anyhow::Result<ShouldContinue> + Send + Sync + 'static>;
 
 pub struct System {
-    pub prepare: fn(&mut LoanManager<'_>) -> anyhow::Result<Resource>,
+    pub prepare: fn(&mut LoanManager<'_>) -> anyhow::Result<TypeValue>,
     pub function: SystemFunction,
 }
 
 impl System {
-    pub fn run(&mut self, data: Resource) -> anyhow::Result<ShouldContinue> {
+    pub fn run(&mut self, data: TypeValue) -> anyhow::Result<ShouldContinue> {
         (self.function)(data)
     }
 
@@ -70,25 +74,25 @@ impl System {
         mut sys_fn: F,
         runs_before: &[&str],
         runs_after: &[&str],
-    ) -> Node<Self, TypeId>
+    ) -> Node<Self, TypeKey>
     where
         F: FnMut(T) -> anyhow::Result<ShouldContinue> + Send + Sync + 'static,
         T: CanFetch + Send + Sync + 'static,
     {
         let (writes, reads): (Vec<_>, Vec<_>) = T::borrows().into_iter().partition_map(|borrow| {
             if borrow.is_exclusive() {
-                itertools::Either::Left(borrow.rez_id().type_id)
+                itertools::Either::Left(borrow.rez_id())
             } else {
-                itertools::Either::Right(borrow.rez_id().type_id)
+                itertools::Either::Right(borrow.rez_id())
             }
         });
 
         let system = System {
             prepare: |loan_mngr: &mut LoanManager| {
-                let rez: Resource = Resource::from(Box::new(T::construct(loan_mngr)?));
+                let rez: TypeValue = TypeValue::from(Box::new(T::construct(loan_mngr)?));
                 Ok(rez)
             },
-            function: Box::new(move |b: Resource| {
+            function: Box::new(move |b: TypeValue| {
                 let box_t: Box<T> = b.downcast().ok().context("cannot downcast")?;
                 let t: T = *box_t;
                 sys_fn(t)


### PR DESCRIPTION
This parts out resource management into a new crate `broomdog`.  